### PR TITLE
Fall back on tag_name if release has no name

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -222,7 +222,7 @@ export class AppComponent implements OnInit {
 	getTotalDownloads(): void {
 		for (let i = 0; i < this.json.length; i++) {
 			let assets = this.json[i].assets;
-			let name: string = this.json[i].name ?? this.json[i].tag_name;
+			let name: string = this.json[i].name || this.json[i].tag_name;
 			var downloads: number = 0;
 			for (let x = 0; x < assets.length; x++) {
 				downloads += assets[x].download_count;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -222,7 +222,7 @@ export class AppComponent implements OnInit {
 	getTotalDownloads(): void {
 		for (let i = 0; i < this.json.length; i++) {
 			let assets = this.json[i].assets;
-			let name: string = this.json[i].name;
+			let name: string = this.json[i].name ?? this.json[i].tag_name;
 			var downloads: number = 0;
 			for (let x = 0; x < assets.length; x++) {
 				downloads += assets[x].download_count;


### PR DESCRIPTION
Hey, just found your site today as I was learning the GitHub API. Thanks for putting this together!

There's one small suggestion I'd like to make. On the GitHub releases page, if you don't give your release a "name", then it will populate the header with the release's "tag_name" instead. I had not been giving my releases names in one repo, so my API responses came back looking like this:

```json
{
  "name": "",
  "tag_name": "v1.2.0"
}
```

...which resulted in a bunch of unnamed releases in your download counter.

So my suggestion is simply to copy what the Releases page does and fall back on "tag_name" if "name" is empty when grouping download numbers. Here's a super-quick, untested solution to implement that - take it if you'd like! And feel free to use [this repo](https://github.com/runeberry/PlayerMadeQuests) to test it out.